### PR TITLE
Add case for 59 to prefix functions

### DIFF
--- a/src/etc/inc/pfsense-utils.inc
+++ b/src/etc/inc/pfsense-utils.inc
@@ -2978,6 +2978,7 @@ function merge_ipv6_delegated_prefix($prefix, $suffix, $len = 64) {
 	case 56:
 		$prefix_len = 17;
 		break;
+	case 59:
 	case 60:
 		$prefix_len = 18;
 		break;
@@ -3015,6 +3016,7 @@ function dhcpv6_pd_str_help($pdlen) {
 	case 56:
 		$result = '::xx:xxxx:xxxx:xxxx:xxxx';
 		break;
+	case 59:
 	case 60:
 		$result = '::x:xxxx:xxxx:xxxx:xxxx';
 		break;


### PR DESCRIPTION
Maybe these functions should have a case added for prefix length 59?